### PR TITLE
Fix main window failing to reopen when clicking Dock icon

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -231,4 +231,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             // Focus search field (handled in SwiftUI)
         }
     }
+    
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if !flag {
+            showMainWindow()
+        }
+        return true
+    }
 }


### PR DESCRIPTION
Resolves #13. Implements `applicationShouldHandleReopen(_:hasVisibleWindows:)` in `AppDelegate` to ensure the main window reopens when the dock icon is clicked and no windows are active.