### PR TITLE
feat: add profile management UI and logic

### DIFF
--- a/Sources/DataManager.swift
+++ b/Sources/DataManager.swift
@@ -120,6 +120,35 @@ class DataManager: ObservableObject {
         return category.items.randomElement()
     }
     
+    // MARK: - Profile Mutations
+    
+    func addProfile(name: String) {
+        let newProfile = Profile(id: UUID().uuidString, name: name, categories: [])
+        if data == nil {
+            data = GhostwriterData(profiles: [newProfile])
+        } else {
+            data?.profiles.append(newProfile)
+        }
+        activeProfileId = newProfile.id
+        saveData()
+    }
+    
+    func renameProfile(id: String, newName: String) {
+        guard let index = data?.profiles.firstIndex(where: { $0.id == id }) else { return }
+        data?.profiles[index].name = newName
+        saveData()
+    }
+    
+    func deleteProfile(id: String) {
+        guard let index = data?.profiles.firstIndex(where: { $0.id == id }) else { return }
+        data?.profiles.remove(at: index)
+        
+        if activeProfileId == id {
+            activeProfileId = data?.profiles.first?.id
+        }
+        saveData()
+    }
+    
     // MARK: - Category Mutations
     
     func renameCategory(profileId: String, categoryId: String, newName: String) {

--- a/Sources/MainWindow.swift
+++ b/Sources/MainWindow.swift
@@ -24,10 +24,21 @@ struct MainContentView: View {
     @ObservedObject var dataManager: DataManager
     @State private var selectedProfileId: String?
     
+    @State private var showAddProfile = false
+    @State private var profileToRename: Profile?
+    @State private var profileToDelete: Profile?
+    
     var body: some View {
         NavigationSplitView {
             List(selection: $selectedProfileId) {
-                Section(header: Text("Profiles")) {
+                Section(header: HStack {
+                    Text("Profiles")
+                    Spacer()
+                    Button(action: { showAddProfile = true }) {
+                        Image(systemName: "plus")
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                }) {
                     if let data = dataManager.data {
                         ForEach(data.profiles) { profile in
                             NavigationLink(value: profile.id) {
@@ -40,6 +51,10 @@ struct MainContentView: View {
                                             .foregroundColor(.green)
                                     }
                                 }
+                            }
+                            .contextMenu {
+                                Button("Rename") { profileToRename = profile }
+                                Button("Delete") { profileToDelete = profile }
                             }
                         }
                     } else {
@@ -69,6 +84,26 @@ struct MainContentView: View {
             }
         }
         .accentColor(Color(red: 0.18, green: 0.35, blue: 0.55)) // Deep Ghostwriter Blue
+        .sheet(isPresented: $showAddProfile) {
+            AddProfileView(dataManager: dataManager)
+        }
+        .sheet(item: $profileToRename) { profile in
+            RenameProfileView(dataManager: dataManager, profile: profile)
+        }
+        .alert("Delete Profile", isPresented: Binding(
+            get: { profileToDelete != nil },
+            set: { if !$0 { profileToDelete = nil } }
+        ), presenting: profileToDelete) { profile in
+            Button("Delete", role: .destructive) {
+                dataManager.deleteProfile(id: profile.id)
+                if selectedProfileId == profile.id {
+                    selectedProfileId = nil
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { profile in
+            Text("Are you sure you want to delete '\(profile.name)'?")
+        }
     }
 }
 
@@ -298,5 +333,85 @@ struct SettingsView: View {
                 dataManager.generateTemplate(at: url)
             }
         }
+    }
+}
+
+// MARK: - Profile Management Sheets
+
+struct AddProfileView: View {
+    @ObservedObject var dataManager: DataManager
+    @Environment(\.presentationMode) var presentationMode
+    @State private var profileName: String = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("New Profile")
+                .font(.title2).fontWeight(.bold)
+
+            TextField("Profile name", text: $profileName)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit { commit() }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { presentationMode.wrappedValue.dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Create") { commit() }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(profileName.trimmingCharacters(in: .whitespaces).isEmpty)
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(24)
+        .frame(width: 360)
+        .accentColor(Color(red: 0.18, green: 0.35, blue: 0.55))
+    }
+
+    private func commit() {
+        let trimmed = profileName.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        dataManager.addProfile(name: trimmed)
+        presentationMode.wrappedValue.dismiss()
+    }
+}
+
+struct RenameProfileView: View {
+    @ObservedObject var dataManager: DataManager
+    let profile: Profile
+    @Environment(\.presentationMode) var presentationMode
+    @State private var profileName: String = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("Rename Profile")
+                .font(.title2).fontWeight(.bold)
+
+            TextField("Profile name", text: $profileName)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit { commit() }
+                .onAppear {
+                    profileName = profile.name
+                }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { presentationMode.wrappedValue.dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Rename") { commit() }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(profileName.trimmingCharacters(in: .whitespaces).isEmpty)
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(24)
+        .frame(width: 360)
+        .accentColor(Color(red: 0.18, green: 0.35, blue: 0.55))
+    }
+
+    private func commit() {
+        let trimmed = profileName.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        dataManager.renameProfile(id: profile.id, newName: trimmed)
+        presentationMode.wrappedValue.dismiss()
     }
 }

--- a/Tests/GhostwriterTests/DataManagerTests.swift
+++ b/Tests/GhostwriterTests/DataManagerTests.swift
@@ -38,4 +38,51 @@ final class DataManagerTests: XCTestCase {
     // Note: Methods like addCategory, addItem, etc. currently write to disk
     // via saveData(). In a fully testable architecture, we would inject a mock file manager
     // or a custom URL. For now, we are asserting basic read logic.
+    
+    // MARK: - Profile Mutation Tests
+    
+    func testAddProfile() {
+        let initialCount = manager.data?.profiles.count ?? 0
+        manager.addProfile(name: "New Profile")
+        
+        XCTAssertEqual(manager.data?.profiles.count, initialCount + 1)
+        XCTAssertEqual(manager.data?.profiles.last?.name, "New Profile")
+        XCTAssertEqual(manager.activeProfileId, manager.data?.profiles.last?.id)
+    }
+    
+    func testRenameProfile() {
+        manager.addProfile(name: "Old Name")
+        let newProfileId = manager.data!.profiles.last!.id
+        
+        manager.renameProfile(id: newProfileId, newName: "Renamed Profile")
+        
+        let updatedProfile = manager.data?.profiles.first(where: { $0.id == newProfileId })
+        XCTAssertEqual(updatedProfile?.name, "Renamed Profile")
+    }
+    
+    func testDeleteProfile() {
+        manager.addProfile(name: "To Delete")
+        let newProfileId = manager.data!.profiles.last!.id
+        let countBeforeDelete = manager.data!.profiles.count
+        
+        manager.deleteProfile(id: newProfileId)
+        
+        XCTAssertEqual(manager.data?.profiles.count, countBeforeDelete - 1)
+        XCTAssertNil(manager.data?.profiles.first(where: { $0.id == newProfileId }))
+    }
+    
+    func testDeleteActiveProfileUpdatesActiveProfileId() {
+        // Setup a secondary profile
+        manager.addProfile(name: "Secondary Profile")
+        let secondaryId = manager.data!.profiles.last!.id
+        
+        // Ensure the active profile is the secondary one
+        XCTAssertEqual(manager.activeProfileId, secondaryId)
+        
+        // Delete it
+        manager.deleteProfile(id: secondaryId)
+        
+        // The active profile should fall back to the first available one ("test-profile-1" from setUp)
+        XCTAssertEqual(manager.activeProfileId, "test-profile-1")
+    }
 }


### PR DESCRIPTION
Fixes #15. Implements the ability to add, rename, and delete profiles from the UI. Also includes unit tests for the DataManager profile mutations.