### PR TITLE
feat: customizable global shortcut

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10,6 +10,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var commandPaletteWindow: NSWindow?
     var mainWindowController: MainWindowController?
     private var cancellables = Set<AnyCancellable>()
+    
+    var globalHotKeyRef: EventHotKeyRef?
+    var hasInstalledGlobalHotkeyHandler = false
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         setupMainMenu()
@@ -39,6 +42,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 self?.setupMenu()
             }
             .store(in: &cancellables)
+            
+        NotificationCenter.default.addObserver(self, selector: #selector(setupGlobalHotkey), name: NSNotification.Name("UpdateGlobalHotkey"), object: nil)
         
         showMainWindow()
     }
@@ -198,35 +203,42 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         commandPaletteWindow = CommandPaletteWindow.create(dataManager: dataManager)
     }
     
-    func setupGlobalHotkey() {
-        // Switch to Carbon Event HotKeys for more robust global registration 
-        // that often bypasses the strict Accessibility requirement bugs.
-        var hotKeyRef: EventHotKeyRef?
+    @objc func setupGlobalHotkey() {
+        if let ref = globalHotKeyRef {
+            UnregisterEventHotKey(ref)
+            globalHotKeyRef = nil
+        }
+        
+        let defaults = UserDefaults.standard
+        let savedKeyCode = defaults.object(forKey: "shortcutKeyCode") as? UInt32
+        let savedModifiers = defaults.object(forKey: "shortcutModifiers") as? UInt32
+        
+        // Fallback defaults: Cmd + Shift + P
+        let keyCode = savedKeyCode ?? 35 
+        let modifierFlags = savedModifiers ?? UInt32(cmdKey | shiftKey)
+        
         let hotKeyID = EventHotKeyID(signature: 0x47575254, id: 1) // 'GWRT'
         
-        // kVK_ANSI_P is 35. cmdKey is 0x0100, shiftKey is 0x0200
-        let modifierFlags = UInt32(cmdKey | shiftKey)
-        let keyCode: UInt32 = 35 
-        
-        let status = RegisterEventHotKey(keyCode, modifierFlags, hotKeyID, GetApplicationEventTarget(), 0, &hotKeyRef)
+        let status = RegisterEventHotKey(keyCode, modifierFlags, hotKeyID, GetApplicationEventTarget(), 0, &globalHotKeyRef)
         if status != noErr {
             print("Failed to register global hotkey")
         }
         
-        var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
-        
-        let handler: EventHandlerUPP = { (nextHandler, theEvent, userData) -> OSStatus in
-            // Post a notification because this C-function closure cannot capture 'self'
-            DispatchQueue.main.async {
-                NotificationCenter.default.post(name: NSNotification.Name("TogglePaletteShortcut"), object: nil)
+        if !hasInstalledGlobalHotkeyHandler {
+            var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
+            
+            let handler: EventHandlerUPP = { (nextHandler, theEvent, userData) -> OSStatus in
+                DispatchQueue.main.async {
+                    NotificationCenter.default.post(name: NSNotification.Name("TogglePaletteShortcut"), object: nil)
+                }
+                return noErr
             }
-            return noErr
+            
+            InstallEventHandler(GetApplicationEventTarget(), handler, 1, &eventType, nil, nil)
+            NotificationCenter.default.addObserver(self, selector: #selector(showCommandPaletteMenu), name: NSNotification.Name("TogglePaletteShortcut"), object: nil)
+            
+            hasInstalledGlobalHotkeyHandler = true
         }
-        
-        InstallEventHandler(GetApplicationEventTarget(), handler, 1, &eventType, nil, nil)
-        
-        // Listen for the notification
-        NotificationCenter.default.addObserver(self, selector: #selector(showCommandPaletteMenu), name: NSNotification.Name("TogglePaletteShortcut"), object: nil)
     }
     
     @objc func showCommandPaletteMenu() {

--- a/Sources/MainWindow.swift
+++ b/Sources/MainWindow.swift
@@ -273,6 +273,10 @@ extension View {
 struct SettingsView: View {
     @ObservedObject var dataManager: DataManager
     
+    @State private var isRecording = false
+    @State private var localMonitor: Any?
+    @AppStorage("shortcutKeyString") private var shortcutKeyString: String = "Cmd + Shift + P"
+    
     var body: some View {
         VStack(spacing: 20) {
             Image(systemName: "gearshape.2")
@@ -286,6 +290,36 @@ struct SettingsView: View {
                 .multilineTextAlignment(.center)
                 .foregroundColor(.secondary)
                 .padding(.horizontal)
+                
+            Divider()
+                .padding(.vertical)
+                
+            Text("Command Palette Shortcut")
+                .font(.title2)
+                .fontWeight(.semibold)
+            
+            HStack {
+                Text("Current Shortcut:")
+                Text(shortcutKeyString)
+                    .font(.headline)
+                    .padding(6)
+                    .background(Color.secondary.opacity(0.2))
+                    .cornerRadius(4)
+            }
+            
+            HStack {
+                Button(isRecording ? "Press any key combination..." : "Record Shortcut") {
+                    startRecordingShortcut()
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(isRecording ? .red : .accentColor)
+                
+                Button("Reset to Default") {
+                    resetShortcut()
+                }
+                .buttonStyle(.bordered)
+                .disabled(shortcutKeyString == "Cmd + Shift + P")
+            }
                 
             Divider()
                 .padding(.vertical)
@@ -312,6 +346,52 @@ struct SettingsView: View {
             }
         }
         .frame(minWidth: 400, maxWidth: .infinity, minHeight: 400, maxHeight: .infinity)
+        .onDisappear {
+            stopRecording()
+        }
+    }
+    
+    private func startRecordingShortcut() {
+        if isRecording { return }
+        isRecording = true
+        
+        localMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            let carbonMods = ShortcutUtils.carbonModifiers(from: event.modifierFlags)
+            
+            var modsString = ""
+            if event.modifierFlags.contains(.control) { modsString += "Ctrl + " }
+            if event.modifierFlags.contains(.option) { modsString += "Opt + " }
+            if event.modifierFlags.contains(.shift) { modsString += "Shift + " }
+            if event.modifierFlags.contains(.command) { modsString += "Cmd + " }
+            
+            let char = event.charactersIgnoringModifiers?.uppercased() ?? ""
+            let fullString = modsString + char
+            
+            UserDefaults.standard.set(event.keyCode, forKey: "shortcutKeyCode")
+            UserDefaults.standard.set(carbonMods, forKey: "shortcutModifiers")
+            shortcutKeyString = fullString
+            
+            NotificationCenter.default.post(name: NSNotification.Name("UpdateGlobalHotkey"), object: nil)
+            
+            stopRecording()
+            return nil
+        }
+    }
+    
+    private func stopRecording() {
+        isRecording = false
+        if let monitor = localMonitor {
+            NSEvent.removeMonitor(monitor)
+            localMonitor = nil
+        }
+    }
+    
+    private func resetShortcut() {
+        stopRecording()
+        UserDefaults.standard.removeObject(forKey: "shortcutKeyCode")
+        UserDefaults.standard.removeObject(forKey: "shortcutModifiers")
+        shortcutKeyString = "Cmd + Shift + P"
+        NotificationCenter.default.post(name: NSNotification.Name("UpdateGlobalHotkey"), object: nil)
     }
     
     private func importData() {

--- a/Sources/ShortcutUtils.swift
+++ b/Sources/ShortcutUtils.swift
@@ -1,0 +1,13 @@
+import Cocoa
+import Carbon
+
+public struct ShortcutUtils {
+    public static func carbonModifiers(from nsModifiers: NSEvent.ModifierFlags) -> UInt32 {
+        var carbonMods: UInt32 = 0
+        if nsModifiers.contains(.command) { carbonMods |= UInt32(cmdKey) }
+        if nsModifiers.contains(.shift) { carbonMods |= UInt32(shiftKey) }
+        if nsModifiers.contains(.option) { carbonMods |= UInt32(optionKey) }
+        if nsModifiers.contains(.control) { carbonMods |= UInt32(controlKey) }
+        return carbonMods
+    }
+}

--- a/Tests/GhostwriterTests/ShortcutTests.swift
+++ b/Tests/GhostwriterTests/ShortcutTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+import Carbon
+@testable import Ghostwriter
+
+final class ShortcutTests: XCTestCase {
+    func testCarbonModifierMapping() {
+        // Test individual modifiers
+        XCTAssertEqual(ShortcutUtils.carbonModifiers(from: .command), UInt32(cmdKey))
+        XCTAssertEqual(ShortcutUtils.carbonModifiers(from: .shift), UInt32(shiftKey))
+        XCTAssertEqual(ShortcutUtils.carbonModifiers(from: .option), UInt32(optionKey))
+        XCTAssertEqual(ShortcutUtils.carbonModifiers(from: .control), UInt32(controlKey))
+        
+        // Test combinations
+        XCTAssertEqual(ShortcutUtils.carbonModifiers(from: [.command, .shift]), UInt32(cmdKey | shiftKey))
+        XCTAssertEqual(ShortcutUtils.carbonModifiers(from: [.option, .control]), UInt32(optionKey | controlKey))
+        XCTAssertEqual(ShortcutUtils.carbonModifiers(from: [.command, .shift, .option, .control]), UInt32(cmdKey | shiftKey | optionKey | controlKey))
+        
+        // Test empty
+        XCTAssertEqual(ShortcutUtils.carbonModifiers(from: []), 0)
+    }
+}


### PR DESCRIPTION
Fixes #17. Users can now record and save a custom global shortcut in Settings to open the Command Palette. Tested NSEvent modifier to Carbon modifier mappings.