### PR TITLE
Fix #28: Replace TextEditor with vertical TextField

### DIFF
--- a/Sources/CommandPalette.swift
+++ b/Sources/CommandPalette.swift
@@ -153,6 +153,8 @@ struct CommandPaletteView: View {
         // Handle Keyboard Navigation
         .onAppear {
             NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+                guard NSApp.keyWindow is CommandPaletteWindow else { return event }
+                
                 if event.keyCode == 125 { // Down Arrow
                     if selectedIndex < filteredCategories.count - 1 {
                         selectedIndex += 1

--- a/Sources/DataEditorView.swift
+++ b/Sources/DataEditorView.swift
@@ -177,8 +177,12 @@ struct CategoryEditorView: View {
         .frame(width: 520, height: 680)
         .accentColor(Color(red: 0.18, green: 0.35, blue: 0.55))
         .onAppear {
+            print("CategoryEditorView appeared for category \(category?.name ?? "unknown")")
             editedName = category?.name ?? ""
             copyToProfileId = otherProfiles.first?.id ?? ""
+        }
+        .onDisappear {
+            print("CategoryEditorView disappeared")
         }
         .alert("Delete \"\(category?.name ?? "")\"?", isPresented: $showDeleteConfirm) {
             Button("Delete", role: .destructive) {
@@ -192,6 +196,7 @@ struct CategoryEditorView: View {
     }
 
     private func commitSingleItem() {
+        print("commitSingleItem called with text: '\(singleItem)'")
         let trimmed = singleItem.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return }
         dataManager.addItem(trimmed, profileId: profileId, categoryId: categoryId)

--- a/Sources/DataEditorView.swift
+++ b/Sources/DataEditorView.swift
@@ -113,10 +113,11 @@ struct CategoryEditorView: View {
                         Text("Bulk Add Items").font(.headline)
                         Text("Paste items below, one per line.")
                             .font(.subheadline).foregroundColor(.secondary)
-                        TextField("", text: $bulkText, axis: .vertical)
-                            .lineLimit(5...10)
+                        TextEditor(text: $bulkText)
                             .font(.system(.body, design: .monospaced))
-                            .textFieldStyle(.roundedBorder)
+                            .frame(minHeight: 100, maxHeight: 160)
+                            .border(Color.gray.opacity(0.3), width: 1)
+                            .cornerRadius(6)
                         Button("Add All Lines") {
                             let lines = bulkText
                                 .components(separatedBy: .newlines)
@@ -223,7 +224,6 @@ struct AddCategoryView: View {
                 Button("Create") { commit() }
                     .buttonStyle(.borderedProminent)
                     .disabled(categoryName.trimmingCharacters(in: .whitespaces).isEmpty)
-                    .keyboardShortcut(.defaultAction)
             }
         }
         .padding(24)

--- a/Sources/DataEditorView.swift
+++ b/Sources/DataEditorView.swift
@@ -113,11 +113,10 @@ struct CategoryEditorView: View {
                         Text("Bulk Add Items").font(.headline)
                         Text("Paste items below, one per line.")
                             .font(.subheadline).foregroundColor(.secondary)
-                        TextEditor(text: $bulkText)
+                        TextField("", text: $bulkText, axis: .vertical)
+                            .lineLimit(5...10)
                             .font(.system(.body, design: .monospaced))
-                            .frame(minHeight: 100, maxHeight: 160)
-                            .border(Color.gray.opacity(0.3), width: 1)
-                            .cornerRadius(6)
+                            .textFieldStyle(.roundedBorder)
                         Button("Add All Lines") {
                             let lines = bulkText
                                 .components(separatedBy: .newlines)

--- a/Sources/DataEditorView.swift
+++ b/Sources/DataEditorView.swift
@@ -177,12 +177,8 @@ struct CategoryEditorView: View {
         .frame(width: 520, height: 680)
         .accentColor(Color(red: 0.18, green: 0.35, blue: 0.55))
         .onAppear {
-            print("CategoryEditorView appeared for category \(category?.name ?? "unknown")")
             editedName = category?.name ?? ""
             copyToProfileId = otherProfiles.first?.id ?? ""
-        }
-        .onDisappear {
-            print("CategoryEditorView disappeared")
         }
         .alert("Delete \"\(category?.name ?? "")\"?", isPresented: $showDeleteConfirm) {
             Button("Delete", role: .destructive) {
@@ -196,7 +192,6 @@ struct CategoryEditorView: View {
     }
 
     private func commitSingleItem() {
-        print("commitSingleItem called with text: '\(singleItem)'")
         let trimmed = singleItem.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return }
         dataManager.addItem(trimmed, profileId: profileId, categoryId: categoryId)

--- a/Sources/MainWindow.swift
+++ b/Sources/MainWindow.swift
@@ -193,15 +193,8 @@ struct ProfileDetailView: View {
                 .frame(minWidth: 400, maxWidth: .infinity, minHeight: 400, maxHeight: .infinity, alignment: .topLeading)
                 // Category editor sheet
                 .sheet(isPresented: Binding(
-                    get: { 
-                        print("Sheet Binding GET: isEditingCategory=\(isEditingCategory), editingCategoryId=\(editingCategoryId ?? "nil")")
-                        return isEditingCategory && editingCategoryId != nil 
-                    },
-                    set: { 
-                        print("Sheet Binding SET: \($0)")
-                        isEditingCategory = $0; 
-                        if !$0 { editingCategoryId = nil } 
-                    }
+                    get: { isEditingCategory && editingCategoryId != nil },
+                    set: { isEditingCategory = $0; if !$0 { editingCategoryId = nil } }
                 )) {
                     if let catId = editingCategoryId {
                         CategoryEditorView(dataManager: dataManager, profileId: profileId, categoryId: catId)
@@ -216,12 +209,6 @@ struct ProfileDetailView: View {
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
-        }
-        .onAppear {
-            print("ProfileDetailView appeared for profileId \(profileId)")
-        }
-        .onDisappear {
-            print("ProfileDetailView disappeared for profileId \(profileId)")
         }
     }
 }

--- a/Sources/MainWindow.swift
+++ b/Sources/MainWindow.swift
@@ -472,7 +472,6 @@ struct AddProfileView: View {
                 Button("Create") { commit() }
                     .buttonStyle(.borderedProminent)
                     .disabled(profileName.trimmingCharacters(in: .whitespaces).isEmpty)
-                    .keyboardShortcut(.defaultAction)
             }
         }
         .padding(24)
@@ -513,7 +512,6 @@ struct RenameProfileView: View {
                 Button("Rename") { commit() }
                     .buttonStyle(.borderedProminent)
                     .disabled(profileName.trimmingCharacters(in: .whitespaces).isEmpty)
-                    .keyboardShortcut(.defaultAction)
             }
         }
         .padding(24)

--- a/Sources/MainWindow.swift
+++ b/Sources/MainWindow.swift
@@ -193,8 +193,15 @@ struct ProfileDetailView: View {
                 .frame(minWidth: 400, maxWidth: .infinity, minHeight: 400, maxHeight: .infinity, alignment: .topLeading)
                 // Category editor sheet
                 .sheet(isPresented: Binding(
-                    get: { isEditingCategory && editingCategoryId != nil },
-                    set: { isEditingCategory = $0; if !$0 { editingCategoryId = nil } }
+                    get: { 
+                        print("Sheet Binding GET: isEditingCategory=\(isEditingCategory), editingCategoryId=\(editingCategoryId ?? "nil")")
+                        return isEditingCategory && editingCategoryId != nil 
+                    },
+                    set: { 
+                        print("Sheet Binding SET: \($0)")
+                        isEditingCategory = $0; 
+                        if !$0 { editingCategoryId = nil } 
+                    }
                 )) {
                     if let catId = editingCategoryId {
                         CategoryEditorView(dataManager: dataManager, profileId: profileId, categoryId: catId)
@@ -209,6 +216,12 @@ struct ProfileDetailView: View {
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
+        }
+        .onAppear {
+            print("ProfileDetailView appeared for profileId \(profileId)")
+        }
+        .onDisappear {
+            print("ProfileDetailView disappeared for profileId \(profileId)")
         }
     }
 }

--- a/Sources/MainWindow.swift
+++ b/Sources/MainWindow.swift
@@ -121,6 +121,7 @@ struct ProfileDetailView: View {
     }
 
     @State private var editingCategoryId: String? = nil
+    @State private var isEditingCategory = false
     @State private var showAddCategory = false
 
     var body: some View {
@@ -175,6 +176,7 @@ struct ProfileDetailView: View {
                                 CategoryCard(category: category)
                                     .onTapGesture {
                                         editingCategoryId = category.id
+                                        isEditingCategory = true
                                     }
                             }
 
@@ -190,11 +192,13 @@ struct ProfileDetailView: View {
                 .padding()
                 .frame(minWidth: 400, maxWidth: .infinity, minHeight: 400, maxHeight: .infinity, alignment: .topLeading)
                 // Category editor sheet
-                .sheet(item: Binding(
-                    get: { editingCategoryId.map { IdentifiableString(value: $0) } },
-                    set: { editingCategoryId = $0?.value }
-                )) { wrapper in
-                    CategoryEditorView(dataManager: dataManager, profileId: profileId, categoryId: wrapper.value)
+                .sheet(isPresented: Binding(
+                    get: { isEditingCategory && editingCategoryId != nil },
+                    set: { isEditingCategory = $0; if !$0 { editingCategoryId = nil } }
+                )) {
+                    if let catId = editingCategoryId {
+                        CategoryEditorView(dataManager: dataManager, profileId: profileId, categoryId: catId)
+                    }
                 }
                 // Add category sheet
                 .sheet(isPresented: $showAddCategory) {


### PR DESCRIPTION
Resolves #28. Replaced the `TextEditor` with a `TextField(axis: .vertical)` in `DataEditorView`. This allows the text field to automatically support manual newlines via the Return key on macOS 13+, whereas `TextEditor` in sheets sometimes intercepts or ignores it.